### PR TITLE
Update for Python 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: "actions/checkout@v2"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ pytest .
 
 ### unreleased
 
-Nothing yet.
+Add support for Python 3.10.
 
 ### 1.1.0 (06.01.2021)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Topic :: Software Development :: Libraries",
     ]
 requires-python = ">=3.6"


### PR DESCRIPTION
Fixes #21 

- Add "3.10" to GitHub workflow
- Add "3.10" to supported versions in `pyproject.toml`
- Local testing with Python 3.10 passed without changes
- Update README